### PR TITLE
Add support for XCFramework and Apple Silicon for tvOS Simulator

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -218,6 +218,7 @@ mkdir -p "$ARCHIVE/lib/Catalyst"
 fi
 mkdir -p "$ARCHIVE/bin"
 mkdir -p "$ARCHIVE/framework"
+mkdir -p "$ARCHIVE/xcframework"
 
 # libraries
 cp curl/lib/libcurl_iOS.a $ARCHIVE/lib/iOS/libcurl.a
@@ -226,17 +227,33 @@ cp curl/lib/libcurl_iOS-fat.a $ARCHIVE/lib/iOS-fat/libcurl.a
 cp curl/lib/libcurl_tvOS.a $ARCHIVE/lib/tvOS/libcurl.a
 cp curl/lib/libcurl_Mac.a $ARCHIVE/lib/MacOS/libcurl.a
 
+xcodebuild -create-xcframework \
+	-library $ARCHIVE/lib/iOS/libcurl.a \
+	-library $ARCHIVE/lib/iOS-simulator/libcurl.a \
+	-output $ARCHIVE/xcframework/libcurl.xcframework
+
 cp openssl/iOS/lib/libcrypto.a $ARCHIVE/lib/iOS/libcrypto.a
 cp openssl/iOS-simulator/lib/libcrypto.a $ARCHIVE/lib/iOS-simulator/libcrypto.a
 cp openssl/iOS-fat/lib/libcrypto.a $ARCHIVE/lib/iOS-fat/libcrypto.a
 cp openssl/tvOS/lib/libcrypto.a $ARCHIVE/lib/tvOS/libcrypto.a
 cp openssl/Mac/lib/libcrypto.a $ARCHIVE/lib/MacOS/libcrypto.a
 
+xcodebuild -create-xcframework \
+	-library $ARCHIVE/lib/iOS/libcrypto.a \
+	-library $ARCHIVE/lib/iOS-simulator/libcrypto.a \
+	-output $ARCHIVE/xcframework/libcrypto.xcframework
+
+
 cp openssl/iOS/lib/libssl.a $ARCHIVE/lib/iOS/libssl.a
 cp openssl/iOS-simulator/lib/libssl.a $ARCHIVE/lib/iOS-simulator/libssl.a
 cp openssl/iOS-fat/lib/libssl.a $ARCHIVE/lib/iOS-fat/libssl.a
 cp openssl/tvOS/lib/libssl.a $ARCHIVE/lib/tvOS/libssl.a
 cp openssl/Mac/lib/libssl.a $ARCHIVE/lib/MacOS/libssl.a
+
+xcodebuild -create-xcframework \
+	-library $ARCHIVE/lib/iOS/libssl.a \
+	-library $ARCHIVE/lib/iOS-simulator/libssl.a \
+	-output $ARCHIVE/xcframework/libssl.xcframework
 
 if [ "$catalyst" == "-m" ]; then
 	cp curl/lib/libcurl_Catalyst.a $ARCHIVE/lib/Catalyst/libcurl.a
@@ -255,6 +272,12 @@ if [ "$buildnghttp2" != "" ]; then
 	if [ "$catalyst" == "-m" ]; then
 	cp nghttp2/lib/libnghttp2_Catalyst.a $ARCHIVE/lib/Catalyst/libnghttp2.a
 	fi
+
+	xcodebuild -create-xcframework \
+		-library $ARCHIVE/lib/iOS/libnghttp2.a \
+		-library $ARCHIVE/lib/iOS-simulator/libnghttp2.a \
+		-output $ARCHIVE/xcframework/libnghttp2.xcframework
+
 fi
 # archive header files
 cp openssl/iOS/include/openssl/* "$ARCHIVE/include/openssl"

--- a/build.sh
+++ b/build.sh
@@ -213,6 +213,7 @@ mkdir -p "$ARCHIVE/lib/iOS-simulator"
 mkdir -p "$ARCHIVE/lib/iOS-fat"
 mkdir -p "$ARCHIVE/lib/MacOS"
 mkdir -p "$ARCHIVE/lib/tvOS"
+mkdir -p "$ARCHIVE/lib/tvOS-simulator"
 if [ "$catalyst" == "-m" ]; then
 mkdir -p "$ARCHIVE/lib/Catalyst"
 fi
@@ -225,22 +226,28 @@ cp curl/lib/libcurl_iOS.a $ARCHIVE/lib/iOS/libcurl.a
 cp curl/lib/libcurl_iOS-simulator.a $ARCHIVE/lib/iOS-simulator/libcurl.a
 cp curl/lib/libcurl_iOS-fat.a $ARCHIVE/lib/iOS-fat/libcurl.a
 cp curl/lib/libcurl_tvOS.a $ARCHIVE/lib/tvOS/libcurl.a
+cp curl/lib/libcurl_tvOS-simulator.a $ARCHIVE/lib/tvOS-simulator/libcurl.a
 cp curl/lib/libcurl_Mac.a $ARCHIVE/lib/MacOS/libcurl.a
 
 xcodebuild -create-xcframework \
 	-library $ARCHIVE/lib/iOS/libcurl.a \
 	-library $ARCHIVE/lib/iOS-simulator/libcurl.a \
+	-library $ARCHIVE/lib/tvOS/libcurl.a \
+	-library $ARCHIVE/lib/tvOS-simulator/libcurl.a \
 	-output $ARCHIVE/xcframework/libcurl.xcframework
 
 cp openssl/iOS/lib/libcrypto.a $ARCHIVE/lib/iOS/libcrypto.a
 cp openssl/iOS-simulator/lib/libcrypto.a $ARCHIVE/lib/iOS-simulator/libcrypto.a
 cp openssl/iOS-fat/lib/libcrypto.a $ARCHIVE/lib/iOS-fat/libcrypto.a
 cp openssl/tvOS/lib/libcrypto.a $ARCHIVE/lib/tvOS/libcrypto.a
+cp openssl/tvOS-simulator/lib/libcrypto.a $ARCHIVE/lib/tvOS-simulator/libcrypto.a
 cp openssl/Mac/lib/libcrypto.a $ARCHIVE/lib/MacOS/libcrypto.a
 
 xcodebuild -create-xcframework \
 	-library $ARCHIVE/lib/iOS/libcrypto.a \
 	-library $ARCHIVE/lib/iOS-simulator/libcrypto.a \
+	-library $ARCHIVE/lib/tvOS/libcrypto.a \
+	-library $ARCHIVE/lib/tvOS-simulator/libcrypto.a \
 	-output $ARCHIVE/xcframework/libcrypto.xcframework
 
 
@@ -248,11 +255,14 @@ cp openssl/iOS/lib/libssl.a $ARCHIVE/lib/iOS/libssl.a
 cp openssl/iOS-simulator/lib/libssl.a $ARCHIVE/lib/iOS-simulator/libssl.a
 cp openssl/iOS-fat/lib/libssl.a $ARCHIVE/lib/iOS-fat/libssl.a
 cp openssl/tvOS/lib/libssl.a $ARCHIVE/lib/tvOS/libssl.a
+cp openssl/tvOS-simulator/lib/libssl.a $ARCHIVE/lib/tvOS-simulator/libssl.a
 cp openssl/Mac/lib/libssl.a $ARCHIVE/lib/MacOS/libssl.a
 
 xcodebuild -create-xcframework \
 	-library $ARCHIVE/lib/iOS/libssl.a \
 	-library $ARCHIVE/lib/iOS-simulator/libssl.a \
+	-library $ARCHIVE/lib/tvOS/libssl.a \
+	-library $ARCHIVE/lib/tvOS-simulator/libssl.a \
 	-output $ARCHIVE/xcframework/libssl.xcframework
 
 if [ "$catalyst" == "-m" ]; then
@@ -268,6 +278,7 @@ if [ "$buildnghttp2" != "" ]; then
 	cp nghttp2/lib/libnghttp2_iOS-simulator.a $ARCHIVE/lib/iOS-simulator/libnghttp2.a
 	cp nghttp2/lib/libnghttp2_iOS-fat.a $ARCHIVE/lib/iOS-fat/libnghttp2.a
 	cp nghttp2/lib/libnghttp2_tvOS.a $ARCHIVE/lib/tvOS/libnghttp2.a
+	cp nghttp2/lib/libnghttp2_tvOS-simulator.a $ARCHIVE/lib/tvOS-simulator/libnghttp2.a
 	cp nghttp2/lib/libnghttp2_Mac.a $ARCHIVE/lib/MacOS/libnghttp2.a
 	if [ "$catalyst" == "-m" ]; then
 	cp nghttp2/lib/libnghttp2_Catalyst.a $ARCHIVE/lib/Catalyst/libnghttp2.a
@@ -276,6 +287,8 @@ if [ "$buildnghttp2" != "" ]; then
 	xcodebuild -create-xcframework \
 		-library $ARCHIVE/lib/iOS/libnghttp2.a \
 		-library $ARCHIVE/lib/iOS-simulator/libnghttp2.a \
+		-library $ARCHIVE/lib/tvOS/libnghttp2.a \
+		-library $ARCHIVE/lib/tvOS-simulator/libnghttp2.a \
 		-output $ARCHIVE/xcframework/libnghttp2.xcframework
 
 fi

--- a/openssl/openssl-build-phase1.sh
+++ b/openssl/openssl-build-phase1.sh
@@ -340,6 +340,70 @@ buildTVOS()
 	export CPPFLAGS=""
 }
 
+buildTVOSsim()
+{
+	ARCH=$1
+
+	pushd . > /dev/null
+	cd "${OPENSSL_VERSION}"
+
+	PLATFORM="AppleTVSimulator"
+	TARGET="darwin64-${ARCH}-cc"
+	RUNTARGET="-target ${ARCH}-apple-tvos${TVOS_MIN_SDK_VERSION}-simulator"
+
+	export $PLATFORM
+	export SYSROOT=$(xcrun --sdk appletvsimulator --show-sdk-path)
+	export BUILD_TOOLS="${DEVELOPER}"
+	export CC="${BUILD_TOOLS}/usr/bin/gcc -fembed-bitcode -arch ${ARCH}"
+	export LC_CTYPE=C
+
+
+	export CFLAGS=" -Os -fembed-bitcode -arch ${ARCH} ${RUNTARGET} "
+	export LDFLAGS=" -arch ${ARCH} -isysroot ${SYSROOT}"
+	export CPPFLAGS=" -I.. -isysroot ${SYSROOT}"
+	export CXX="${BUILD_TOOLS}/usr/bin/gcc"
+
+	echo -e "${subbold} Building ${OPENSSL_VERSION} for ${PLATFORM} ${TVOS_SDK_VERSION} ${archbold}${ARCH}${dim} (tvOS Simulator ${TVOS_MIN_SDK_VERSION})"
+
+	# Patch apps/speed.c to not use fork() since it's not available on tvOS
+	LANG=C sed -i -- 's/define HAVE_FORK 1/define HAVE_FORK 0/' "./apps/speed.c"
+	if [[ "$OPENSSL_VERSION" = "openssl-1.1.1"* ]]; then
+		LANG=C sed -i -- 's/!defined(OPENSSL_NO_POSIX_IO)/defined(HAVE_FORK)/' "./apps/ocsp.c"
+		LANG=C sed -i -- 's/fork()/-1/' "./apps/ocsp.c"
+		LANG=C sed -i -- 's/fork()/-1/' "./test/drbgtest.c"
+		LANG=C sed -i -- 's/!defined(OPENSSL_NO_ASYNC)/defined(HAVE_FORK)/' "./crypto/async/arch/async_posix.h"
+	fi
+
+	# Patch Configure to build for tvOS, not iOS
+	LANG=C sed -i -- 's/D\_REENTRANT\:iOS/D\_REENTRANT\:tvOS/' "./Configure"
+	chmod u+x ./Configure
+
+	if [[ "$OPENSSL_VERSION" = "openssl-1.1.1"* ]]; then
+		./Configure no-asm  ${TARGET} -no-shared --prefix="/tmp/${OPENSSL_VERSION}-tvOS-Simulator-${ARCH}" --openssldir="/tmp/${OPENSSL_VERSION}-tvOS-Simulator-${ARCH}" $CUSTOMCONFIG &> "/tmp/${OPENSSL_VERSION}-tvOS-Simulator-${ARCH}.log"
+	else
+		./Configure no-asm  --openssldir="/tmp/${OPENSSL_VERSION}-tvOS-Simulator-${ARCH}" $CUSTOMCONFIG &> "/tmp/${OPENSSL_VERSION}-tvOS-Simulator-${ARCH}.log"
+	fi
+
+	# add -isysroot to CC=
+	if [[ "$OPENSSL_VERSION" = "openssl-1.1.1"* ]]; then
+		sed -ie "s!^CFLAGS=!CFLAGS=-isysroot ${SYSROOT} -mtvos-version-min=${TVOS_MIN_SDK_VERSION} !" "Makefile"
+	else
+		sed -ie "s!^CFLAG=!CFLAG=-isysroot ${SYSROOT} -mtvos-version-min=${TVOS_MIN_SDK_VERSION} !" "Makefile"
+	fi
+
+	make -j${CORES} >> "/tmp/${OPENSSL_VERSION}-tvOS-Simulator-${ARCH}.log" 2>&1
+	make install_sw >> "/tmp/${OPENSSL_VERSION}-tvOS-Simulator-${ARCH}.log" 2>&1
+	make clean >> "/tmp/${OPENSSL_VERSION}-tvOS-Simulator-${ARCH}.log" 2>&1
+	popd > /dev/null
+
+	# Clean up exports
+	export CC=""
+	export CXX=""
+	export CFLAGS=""
+	export LDFLAGS=""
+	export CPPFLAGS=""
+}
+
 # echo -e "${bold}Cleaning up${dim}"
 # rm -rf include/openssl/* lib/*
 
@@ -348,6 +412,7 @@ mkdir -p Catalyst/lib
 mkdir -p iOS/lib
 mkdir -p iOS-simulator/lib
 mkdir -p iOS-fat/lib
+mkdir -p tvOS-fat/lib
 mkdir -p tvOS/lib
 mkdir -p Mac/include/openssl/
 mkdir -p Catalyst/include/openssl/
@@ -355,6 +420,8 @@ mkdir -p iOS/include/openssl/
 mkdir -p iOS-simulator/include/openssl/
 mkdir -p iOS-fat/include/openssl/
 mkdir -p tvOS/include/openssl/
+mkdir -p tvOS-simulator/lib
+mkdir -p tvOS-simulator/include/openssl/
 
 rm -rf "/tmp/openssl"
 rm -rf "/tmp/${OPENSSL_VERSION}-*"
@@ -429,19 +496,45 @@ fi
 ## tvOS
 echo -e "${bold}Building tvOS libraries${dim}"
 buildTVOS "arm64"
-buildTVOS "x86_64"
+
 echo "  Copying headers and libraries"
 cp /tmp/${OPENSSL_VERSION}-tvOS-arm64/include/openssl/* tvOS/include/openssl/
 
 lipo \
 	"/tmp/${OPENSSL_VERSION}-tvOS-arm64/lib/libcrypto.a" \
-	"/tmp/${OPENSSL_VERSION}-tvOS-x86_64/lib/libcrypto.a" \
 	-create -output tvOS/lib/libcrypto.a
 
 lipo \
 	"/tmp/${OPENSSL_VERSION}-tvOS-arm64/lib/libssl.a" \
-	"/tmp/${OPENSSL_VERSION}-tvOS-x86_64/lib/libssl.a" \
 	-create -output tvOS/lib/libssl.a
+
+
+echo -e "${bold}Building tvOS simulator libraries${dim}"
+buildTVOSsim "arm64"
+buildTVOSsim "x86_64"
+
+lipo \
+	"/tmp/${OPENSSL_VERSION}-tvOS-arm64/lib/libcrypto.a" \
+	"/tmp/${OPENSSL_VERSION}-tvOS-Simulator-x86_64/lib/libcrypto.a" \
+	-create -output tvOS-fat/lib/libcrypto.a
+
+lipo \
+	"/tmp/${OPENSSL_VERSION}-tvOS-arm64/lib/libssl.a" \
+	"/tmp/${OPENSSL_VERSION}-tvOS-Simulator-x86_64/lib/libssl.a" \
+	-create -output tvOS-fat/lib/libssl.a
+
+echo "  Copying headers and libraries"
+cp /tmp/${OPENSSL_VERSION}-tvOS-Simulator-x86_64/include/openssl/* tvOS-simulator/include/openssl/
+
+lipo \
+	"/tmp/${OPENSSL_VERSION}-tvOS-Simulator-arm64/lib/libcrypto.a" \
+	"/tmp/${OPENSSL_VERSION}-tvOS-Simulator-x86_64/lib/libcrypto.a" \
+	-create -output tvOS-simulator/lib/libcrypto.a
+
+lipo \
+	"/tmp/${OPENSSL_VERSION}-tvOS-Simulator-arm64/lib/libssl.a" \
+	"/tmp/${OPENSSL_VERSION}-tvOS-Simulator-x86_64/lib/libssl.a" \
+	-create -output tvOS-simulator/lib/libssl.a
 
 if [ $catalyst == "1" ]; then
 	libtool -no_warning_for_no_symbols -static -o openssl-ios-x86_64-maccatalyst.a Catalyst/lib/libcrypto.a Catalyst/lib/libssl.a


### PR DESCRIPTION
## Summary
* Update the tvOS scripts for all the dependencies to generate arm64 slices against
 AppleTVSimulator SDK.
* Update the build script to generate XCFrameworks
* Ensure xcframework also includes tvOS slices

I primarily tried to follow the pattern for scripts, as I am not sure the exact reasoning behind all the arguments passed to configure. So there is likely a bit of refactoring required.

## Next Steps:
- [ ] Update the XCFrameworks to also incorporate Mac and Mac Catalyst.
This is likely very quick update, but I'd rather leave it for another PR. 