### PR TITLE
Release 1.0.3 - SSLv3 Support and Enhancements

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,14 @@
 # RELEASE NOTES
 
+## 1.0.3 - SSLv3 Support and Enhancements
+
+* Added SSLv3 support for security testing with `-3` flag. This allows verification that servers properly reject SSLv3 connections. Includes compatibility updates for OpenSSL 3.x which removed the `SSLv3_client_method()` function.
+* Enhanced SSLv3 patch (`sslv3.patch`) to work with OpenSSL 3.x using `SSL_CTX_set_min_proto_version()` and `SSL_CTX_set_max_proto_version()` APIs.
+* Added automatic SSLv3 support verification in build script when `-3` flag is used.
+* Updated `iCurlHTTP.sh` script to copy all `.xcframework` folders from `archive/latest/xcframework` to support modern Xcode projects.
+* Fixed libcurl-build.sh SSLv3 patching for curl 8.17.0+ to properly handle the new command-line argument processing in tool_getparam.c.
+* Improved documentation with detailed patch file comments.
+
 ## 1.0.2 - Removal of armv7
 
 * Removal of armv7/armv7s architecture support: Apple officially stopped supporting the creation of binaries for armv7/armv7s architectures with the release of Xcode 14 in June 2022. This means that new installations of Xcode will not be able to compile armv7 targets, which will break the build script.

--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ BUILD_MACHINE=`uname -m`
 BUILD_CMD=$*
 
 # Script Version
-SCRIPT_VERSION="1.0.2"
+SCRIPT_VERSION="1.0.3"
 
 # Compile Cache - Optional
 # export CMAKE_CXX_COMPILER_LAUNCHER="ccache"
@@ -265,6 +265,10 @@ fi
 mkdir -p "$ARCHIVE/bin"
 mkdir -p "$ARCHIVE/framework"
 mkdir -p "$ARCHIVE/xcframework"
+
+# Create a symlink of latest build
+rm -f archive/latest
+ln -s "libcurl-$LIBCURL-openssl-$OPENSSL-nghttp2-$NGHTTP2" archive/latest
 
 # libraries for libcurl, libcrypto and libssl
 if [ "$BUILDFOR" == "ios" ] || [ "$BUILDFOR" == "all" ]; then

--- a/curl/libcurl-build.sh
+++ b/curl/libcurl-build.sh
@@ -677,8 +677,8 @@ if [ $BUILDFOR == "tvos" ] || [ $BUILDFOR == "all" ]; then
 fi
 
 echo -e "${bold}Cleaning up${dim}"
-#rm -rf /tmp/${CURL_VERSION}-*
-#rm -rf ${CURL_VERSION}
+rm -rf /tmp/${CURL_VERSION}-*
+rm -rf ${CURL_VERSION}
 
 echo -e "${dim}Checking libraries"
 xcrun -sdk iphoneos lipo -info lib/*.a

--- a/curl/libcurl-build.sh
+++ b/curl/libcurl-build.sh
@@ -274,6 +274,15 @@ buildMac()
 	if [ $ARCH == ${BUILD_MACHINE} ]; then
 		echo -e "Testing binary for ${BUILD_MACHINE}:"
 		/tmp/curl -V
+		# if user requested SSLv3, test it
+		if [ ${FORCE_SSLV3} == 'yes' ]; then
+			echo -e "Testing SSLv3 support..."
+			if /tmp/curl --sslv3 -V 2>&1 | grep -q "Ignores instruction to use SSLv3"; then
+				echo -e "${alert}ERROR: SSLv3 support not enabled in binary${normal}"
+			else
+				echo -e "${green}SUCCESS: SSLv3 support is enabled${normal}"
+			fi
+		fi
 	fi
 }
 
@@ -567,6 +576,19 @@ if [ ${FORCE_SSLV3} == 'yes' ]; then
 		# for command line
 		sed -i '' -e 's/warnf(global, \"Ignores instruction to use SSLv3\");/config->ssl_version = CURL_SSLVERSION_SSLv3;/g' "${CURL_VERSION}/src/tool_getparam.c"
 		sed -i '' -e 's/warnf(global, \"Ignores instruction to use SSLv3\\n\");/config->ssl_version = CURL_SSLVERSION_SSLv3;/g' "${CURL_VERSION}/src/tool_getparam.c"
+		# fix sslv3 argument deprecated flag in tool_getparams.c
+		sed -i '' '/{"sslv3",/ s/ARG_NONE|ARG_DEPR/ARG_NONE/' "${CURL_VERSION}/src/tool_getparam.c"
+		# add C_SSLV3 case handler in opt_none() function - use value 99 as marker for SSLv3
+		sed -i '' '/case C_IPV4:/i\
+  case C_SSLV3: /* --sslv3 */\
+    config->ssl_version = 99; /* special marker for SSLv3 */\
+    break;
+' "${CURL_VERSION}/src/tool_getparam.c"
+		# patch config2setopts.c to handle SSLv3 marker value before calling tlsversion()
+		sed -i '' '/my_setopt_SSLVERSION(curl, CURLOPT_SSLVERSION,/,/);/{
+s/my_setopt_SSLVERSION(curl, CURLOPT_SSLVERSION,$/my_setopt_SSLVERSION(curl, CURLOPT_SSLVERSION,/
+s/tlsversion(config->ssl_version,$/config->ssl_version == 99 ? CURL_SSLVERSION_SSLv3 : tlsversion(config->ssl_version,/
+}' "${CURL_VERSION}/src/config2setopts.c"
 	fi
 fi
 
@@ -655,8 +677,8 @@ if [ $BUILDFOR == "tvos" ] || [ $BUILDFOR == "all" ]; then
 fi
 
 echo -e "${bold}Cleaning up${dim}"
-rm -rf /tmp/${CURL_VERSION}-*
-rm -rf ${CURL_VERSION}
+#rm -rf /tmp/${CURL_VERSION}-*
+#rm -rf ${CURL_VERSION}
 
 echo -e "${dim}Checking libraries"
 xcrun -sdk iphoneos lipo -info lib/*.a

--- a/curl/sslv3.7.77.0.patch
+++ b/curl/sslv3.7.77.0.patch
@@ -1,4 +1,5 @@
-# SSLv3 Support Patch for curl > 7.77.0 with OpenSSL 3.x
+# SSLv3 Support Patch for curl 7.77.0 with OpenSSL 3.x
+# NOTE: Use this patch only for curl 7.77.0
 # 
 # This patch enables SSLv3 protocol support for security testing purposes.
 # SSLv3 is an obsolete and insecure protocol (deprecated since 2015) but may
@@ -17,18 +18,19 @@
 #
 --- openssl.c	2022-05-30 01:05:13.000000000 -0700
 +++ openssl.c.2	2022-05-30 01:25:52.000000000 -0700
-@@ -2709,8 +2709,8 @@
+@@ -2709,8 +2709,9 @@
      failf(data, "No SSLv2 support");
      return CURLE_NOT_BUILT_IN;
    case CURL_SSLVERSION_SSLv3:
 -    failf(data, "No SSLv3 support");
 -    return CURLE_NOT_BUILT_IN;
-+    /* SSLv3 handled in ossl_connect_step1 via SSL_CTX_set_min/max_proto_version */
++    req_method = SSLv3_client_method();
++    /* use_sni(FALSE); */
 +    break;
    default:
      failf(data, "Unrecognized parameter passed via CURLOPT_SSLVERSION");
      return CURLE_SSL_CONNECT_ERROR;
-@@ -2798,9 +2798,18 @@
+@@ -2798,9 +2799,18 @@
  
    switch(ssl_version) {
      case CURL_SSLVERSION_SSLv2:
@@ -36,8 +38,8 @@
        return CURLE_NOT_BUILT_IN;
  
 +    case CURL_SSLVERSION_SSLv3:
-+      SSL_CTX_set_min_proto_version(octx, SSL3_VERSION);
-+      SSL_CTX_set_max_proto_version(octx, SSL3_VERSION);
++      SSL_CTX_set_min_proto_version(backend->ctx, SSL3_VERSION);
++      SSL_CTX_set_max_proto_version(backend->ctx, SSL3_VERSION);
 +      ctx_options |= SSL_OP_NO_SSLv2;
 +      ctx_options |= SSL_OP_NO_TLSv1;
 +      ctx_options |= SSL_OP_NO_TLSv1_1;

--- a/example/iOS Test App/iOS Test App/ViewController.m
+++ b/example/iOS Test App/iOS Test App/ViewController.m
@@ -205,7 +205,7 @@ int iOSCurlProgressCallback(void *clientp, double dltotal, double dlnow, double 
         curl_easy_setopt(_curl, CURLOPT_USERAGENT, curl_version());	// set a default user agent
         curl_easy_setopt(_curl, CURLOPT_VERBOSE, 1L);	// turn on verbose
         curl_easy_setopt(_curl, CURLOPT_TIMEOUT, 60L); // seconds
-        curl_easy_setopt(_curl, CURLOPT_MAXCONNECTS, 0L); // this should disallow connection sharing
+        // curl_easy_setopt(_curl, CURLOPT_MAXCONNECTS, 0L); // REMOVED - 0 is invalid in curl 8.x
         curl_easy_setopt(_curl, CURLOPT_FORBID_REUSE, 1L); // enforce connection to be closed
         curl_easy_setopt(_curl, CURLOPT_DNS_CACHE_TIMEOUT, 0L); // Disable DNS cache
         curl_easy_setopt(_curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0); // enable HTTP2 Protocol
@@ -227,8 +227,8 @@ int iOSCurlProgressCallback(void *clientp, double dltotal, double dlnow, double 
         // PERFORM the Curl
         theResult = curl_easy_perform(_curl);
         if (theResult == CURLE_OK) {
-            long http_code, http_ver;
-            double total_time, total_size, total_speed, timing_ns, timing_tcp, timing_ssl, timing_fb;
+            long http_code, http_ver, total_size, total_speed;
+            double total_time, timing_ns, timing_tcp, timing_ssl, timing_fb;
             char *redirect_url2 = NULL;
             curl_easy_getinfo(_curl, CURLINFO_RESPONSE_CODE, &http_code);
             curl_easy_getinfo(_curl, CURLINFO_TOTAL_TIME, &total_time);
@@ -256,7 +256,7 @@ int iOSCurlProgressCallback(void *clientp, double dltotal, double dlnow, double 
             }
             
             // timings
-            _resultText.text = [_resultText.text stringByAppendingFormat:@"\n** Timing Details **\n-- \tName Lookup:\t%0.2fs\n-- \tTCP Connect: \t%0.2fs\n-- \tSSL Handshake: \t%0.2fs\n-- \tFirst Byte: \t\t%0.2fs\n-- \tTotal Download: \t%0.2fs\n-- Size: %0.0f bytes\n-- Speed: %0.0f bytes/sec\n-- Using: %@\n** RESULT CODE: %ld**",
+            _resultText.text = [_resultText.text stringByAppendingFormat:@"\n** Timing Details **\n-- \tName Lookup:\t%0.2fs\n-- \tTCP Connect: \t%0.2fs\n-- \tSSL Handshake: \t%0.2fs\n-- \tFirst Byte: \t\t%0.2fs\n-- \tTotal Download: \t%0.2fs\n-- Size: %" CURL_FORMAT_CURL_OFF_T " bytes\n-- Speed: %" CURL_FORMAT_CURL_OFF_T " bytes/sec\n-- Using: %@\n** RESULT CODE: %ld**",
                                 timing_ns,timing_tcp,timing_ssl,timing_fb,
                                 total_time,total_size, total_speed, http_ver_s, http_code];
         

--- a/example/iOS Test App/include/openssl/configuration.h
+++ b/example/iOS Test App/include/openssl/configuration.h
@@ -97,12 +97,6 @@ extern "C" {
 # ifndef OPENSSL_NO_SCTP
 #  define OPENSSL_NO_SCTP
 # endif
-# ifndef OPENSSL_NO_SSL3
-#  define OPENSSL_NO_SSL3
-# endif
-# ifndef OPENSSL_NO_SSL3_METHOD
-#  define OPENSSL_NO_SSL3_METHOD
-# endif
 # ifndef OPENSSL_NO_TRACE
 #  define OPENSSL_NO_TRACE
 # endif


### PR DESCRIPTION
- Added SSLv3 support for security testing with -3 flag
- Enhanced SSLv3 patch for OpenSSL 3.x compatibility
- Added SSLv3 verification in build script
- Updated iCurlHTTP.sh to copy xcframework folders
- Fixed libcurl-build.sh SSLv3 patching for curl 8.17.0+
- Improved patch file documentation